### PR TITLE
Improve error messaging for unstaged files

### DIFF
--- a/src/release/push-to-main.ts
+++ b/src/release/push-to-main.ts
@@ -10,7 +10,29 @@ export const pushToMain = async (ctx: AppContext) => {
 
   // sometimes when pushing to main we get an error that we need to integrate
   // remote changes first, let's pull main and rebase
-  await git.pull("origin", "main", ["--rebase"])
+  try {
+    await git.pull("origin", "main", ["--rebase"])
+  } catch (e: any) {
+    if (e.toString().includes("unstaged changes")) {
+      const status = await git.status()
+      const changed_files = [
+        ...status.not_added,
+        ...status.created,
+        ...status.deleted,
+        ...status.modified,
+        ...status.renamed.map((r) => r.to),
+      ]
+      if (changed_files.length) {
+        console.error(
+          "Cannot pull with rebase due to unstaged changes in the following files:"
+        )
+        for (const file of changed_files) {
+          console.error(" -", file)
+        }
+      }
+    }
+    throw e
+  }
 
   await git.push(["origin", `HEAD:${process.env.GITHUB_REF ?? "main"}`])
 }


### PR DESCRIPTION
## Summary
- enhance error message when push to main fails because of unstaged files

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:analyze`


------
https://chatgpt.com/codex/tasks/task_b_68472177754c832eb6dd4a118fcf7456