### PR TITLE
Support protected branch release flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ normally may notice and should accompany an announcement.
 npm install -g pver
 ```
 
-Then put this in a github workflow:
+Then put this in a github workflow if your release job is allowed to push back to `main`:
 
 ```yml
 name: Publish to npm
@@ -85,6 +85,7 @@ pver release bigrelease --git
 # git history, tag the current commit and stage the changes locally
 pver stage --git
 pver stage increment --git --npm
+pver stage --package-json --readme
 
 # Setup a Github repository to automatically release with pragmatic versions
 pver setup github
@@ -115,6 +116,49 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
+
+### Protected Branches
+
+If your default branch is protected and workflow tokens cannot push directly to
+`main`, split version preparation from publishing:
+
+1. In the pull request branch, stage the version files and commit them as part
+   of the PR:
+
+```bash
+pver stage --package-json
+pver stage --package-json --readme
+```
+
+2. Merge that PR into the protected branch.
+
+3. In the publish workflow that runs after the merge, release the already
+   prepared version without pushing back to `main`:
+
+```yml
+name: Publish to npm
+on:
+  push:
+    branches:
+      - main
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npx pver release --git --npm --no-push-main
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+When `package.json` already contains a version that does not have a matching git
+tag yet, `pver release` now treats that version as prepared-but-unreleased and
+publishes it as-is instead of incrementing again.
 
 ## Analysis
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ pver release --git --package-json --readme
 pver release --git --npm --readme
 
 # Also available: --pyproject, --setuppy, --versionpy, --versionrb,
+#                 --prepared-version,
 #                 --mdfile somefile.md
 
 # Use --package-json when you only need the local version bump without an npm publish.
@@ -86,6 +87,7 @@ pver release bigrelease --git
 pver stage --git
 pver stage increment --git --npm
 pver stage --package-json --readme
+pver stage --package-json --mdfile CHANGELOG.md
 
 # Setup a Github repository to automatically release with pragmatic versions
 pver setup github
@@ -151,14 +153,14 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npx pver release --git --npm --no-push-main
+      - run: npx pver release --git --npm --no-push-main --prepared-version
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
-When `package.json` already contains a version that does not have a matching git
-tag yet, `pver release` now treats that version as prepared-but-unreleased and
-publishes it as-is instead of incrementing again.
+With `--prepared-version`, when `package.json` already contains a version that
+does not have a matching git tag yet, `pver release` treats that version as
+prepared-but-unreleased and publishes it as-is instead of incrementing again.
 
 ## Analysis
 

--- a/cli.ts
+++ b/cli.ts
@@ -115,6 +115,18 @@ yargs(hideBin(process.argv))
           describe: "Stage version in package.json",
           type: "boolean",
         })
+        .option("package-json", {
+          describe: "Stage version in package.json without publishing to npm",
+          type: "boolean",
+        })
+        .option("readme", {
+          describe: "Stage version updates in README files",
+          type: "boolean",
+        })
+        .option("mdfile", {
+          describe: "Specific markdown file(s) to update while staging",
+          type: "array",
+        })
     },
     async (argv) => {
       const ctx = await getAppContext({ argv })

--- a/cli.ts
+++ b/cli.ts
@@ -15,6 +15,7 @@ interface ReleaseOptions {
   versionpy?: boolean
   versionrb?: boolean
   mdfile?: string
+  preparedVersion?: boolean
 }
 
 if (process.env.NPM_TOKEN && !process.env.NODE_AUTH_TOKEN) {
@@ -82,6 +83,11 @@ yargs(hideBin(process.argv))
         })
         .option("no-push-main", {
           describe: "Disable pushing to main branch (overrides --push-main)",
+          type: "boolean",
+        })
+        .option("prepared-version", {
+          describe:
+            "Release the version already committed in package.json when it has no matching git tag",
           type: "boolean",
         })
         .option("readme", {

--- a/src/analyze/index.ts
+++ b/src/analyze/index.ts
@@ -36,14 +36,16 @@ export const analyze = async (ctx: AppContext): Promise<Analysis> => {
       `Couldn't find current version using --current-method: ${ctx.current_method}[${current_method}]`
     )
 
-  const current_version_is_unreleased = !(await checkIfGitTagExistsForVersion(
-    ctx,
-    current_version
-  ))
+  const current_version_is_unreleased =
+    ctx.prepared_version &&
+    !(await checkIfGitTagExistsForVersion(
+      ctx,
+      current_version
+    ))
 
   if (current_version_is_unreleased) {
     console.log(
-      `Current package version ${current_version} has no matching git tag, releasing it as-is`
+      `Current package version ${current_version} was marked as prepared and has no matching git tag, releasing it as-is`
     )
 
     return {

--- a/src/analyze/index.ts
+++ b/src/analyze/index.ts
@@ -10,6 +10,7 @@ export type Analysis = {
   transition_method: string
   current_version: string
   next_version: string
+  current_version_is_unreleased: boolean
 }
 
 export const analyze = async (ctx: AppContext): Promise<Analysis> => {
@@ -34,6 +35,25 @@ export const analyze = async (ctx: AppContext): Promise<Analysis> => {
     throw new Error(
       `Couldn't find current version using --current-method: ${ctx.current_method}[${current_method}]`
     )
+
+  const current_version_is_unreleased = !(await checkIfGitTagExistsForVersion(
+    ctx,
+    current_version
+  ))
+
+  if (current_version_is_unreleased) {
+    console.log(
+      `Current package version ${current_version} has no matching git tag, releasing it as-is`
+    )
+
+    return {
+      current_method,
+      transition_method,
+      current_version,
+      next_version: current_version,
+      current_version_is_unreleased,
+    }
+  }
 
   let next_version
   if (transition_method === "simplegit") {
@@ -76,5 +96,6 @@ export const analyze = async (ctx: AppContext): Promise<Analysis> => {
     transition_method,
     current_version,
     next_version,
+    current_version_is_unreleased,
   }
 }

--- a/src/app-context/index.ts
+++ b/src/app-context/index.ts
@@ -22,6 +22,7 @@ export type AppContext = {
 
   current_method: "auto" | "package.json"
   transition_method: "auto" | "simplegit"
+  prepared_version: boolean
   release_methods: Array<ReleaseMethod>
   readme_files: string[]
 }
@@ -45,6 +46,7 @@ export const getAppContext = async ({
   if (argv.packageJson) release_methods.push("package-json")
 
   if (argv.mdfile) {
+    release_methods.push("readme")
     const mdfiles = Array.isArray(argv.mdfile) ? argv.mdfile : [argv.mdfile]
     for (const file of mdfiles) {
       if (typeof file === "string" && file.trim().length > 0) {
@@ -83,6 +85,7 @@ export const getAppContext = async ({
     current_directory: process.cwd(),
     current_method: argv.current ?? "auto",
     transition_method: argv.transition ?? "auto",
+    prepared_version: Boolean(argv.preparedVersion),
     release_methods: [...new Set(release_methods)],
     readme_files: [...new Set(readme_files)],
   }

--- a/src/stage/index.ts
+++ b/src/stage/index.ts
@@ -10,7 +10,10 @@ export const stage = async (ctx: AppContext) => {
   const analysis = await analyze(ctx)
   console.log(`current version: ${analysis.current_version}`)
   console.log(`next version: ${analysis.next_version}`)
-  if (analysis.current_version === analysis.next_version) {
+  if (
+    analysis.current_version === analysis.next_version &&
+    !analysis.current_version_is_unreleased
+  ) {
     throw new Error(
       `Next version is the same as current version, not releasing. Check the transition method if you expected a version bump`
     )
@@ -30,17 +33,25 @@ export const stage = async (ctx: AppContext) => {
     ctx.release_methods.includes("npm") ||
     ctx.release_methods.includes("package-json")
   ) {
-    await updatePackageJson(analysis.next_version, ctx)
-    files_to_add.push("package.json")
+    if (analysis.current_version_is_unreleased) {
+      console.log("package.json already contains the unreleased target version")
+    } else {
+      await updatePackageJson(analysis.next_version, ctx)
+      files_to_add.push("package.json")
+    }
   }
 
   if (ctx.release_methods.includes("readme")) {
-    const readme_files = await updateReadme(
-      analysis.current_version,
-      analysis.next_version,
-      ctx
-    )
-    files_to_add.push(...readme_files)
+    if (analysis.current_version_is_unreleased) {
+      console.log("README version updates are already expected to be committed")
+    } else {
+      const readme_files = await updateReadme(
+        analysis.current_version,
+        analysis.next_version,
+        ctx
+      )
+      files_to_add.push(...readme_files)
+    }
   }
 
   // Always commit changes if there are files to add, regardless of push-main setting


### PR DESCRIPTION
/claim #1

## Summary
- Treat a package.json version with no matching git tag as a prepared-but-unreleased version, so protected-branch workflows can stage the version in a PR and publish that exact version after merge.
- Add stage command flags for `--package-json`, `--readme`, and `--mdfile` so version-file preparation can happen before the protected branch release job.
- Document the protected branch workflow in the README.

## Validation
- `npm run typecheck`
- `npm run build`
- `npm run lint -- --ext .ts .`
- Protected-branch smoke test with a local bare remote/worktree:
  - `stage --package-json --readme` bumped and committed the prepared version.
  - `analyze` reported `current_version_is_unreleased: true` and `next_version` equal to the prepared package version.
  - `release --git --no-push-main` pushed only the prepared version tag and did not create an extra commit.