### PR TITLE
Support protected-branch release tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,30 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
+### Releasing to Protected Branches
+
+When `main` is protected, the default `GITHUB_TOKEN` usually cannot push version
+bumps unless your branch protection allows the workflow to bypass the rule. For
+protected-branch release workflows, create a fine-grained token or GitHub App
+token that is allowed to push to `main`, save it as `PVER_GITHUB_TOKEN`, and keep
+using `GITHUB_TOKEN` for the rest of the workflow.
+
+```yml
+permissions:
+  contents: write
+
+steps:
+  - uses: actions/checkout@v3
+  - run: pver release --git --package-json --readme
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PVER_GITHUB_TOKEN: ${{ secrets.PVER_GITHUB_TOKEN }}
+```
+
+`PVER_GITHUB_TOKEN` is only used when pver rewrites the `origin` remote for git
+pushes. If it is not set, pver falls back to the existing `GITHUB_TOKEN`
+behavior.
+
 ## Analysis
 
 Analysis has two steps. Getting the `current_version` and using the `transition_method` to

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "cli": "esr ./cli.ts",
+    "test": "esr ./test/configure-origin.test.ts",
     "test:analyze": "esr ./cli.ts analyze",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",

--- a/src/release/configure-origin.ts
+++ b/src/release/configure-origin.ts
@@ -1,24 +1,43 @@
+export const getGithubPushToken = (
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined => {
+  return env.PVER_GITHUB_TOKEN?.trim() || env.GITHUB_TOKEN?.trim()
+}
+
+export const getAuthenticatedGithubRemote = (
+  remote_url: string,
+  token: string
+) => {
+  const clean_remote_url = remote_url.trim().replace(/\n/g, "")
+  const encoded_token = encodeURIComponent(token)
+
+  if (clean_remote_url.includes("oauth2:")) return clean_remote_url
+
+  const ssh_match = clean_remote_url.match(
+    /^git@github\.com:(?<owner>[^/]+)\/(?<repo>.+)$/
+  )
+  const ssh_url_match = clean_remote_url.match(
+    /^ssh:\/\/git@github\.com\/(?<owner>[^/]+)\/(?<repo>.+)$/
+  )
+
+  const https_remote_url =
+    ssh_match?.groups || ssh_url_match?.groups
+      ? `https://github.com/${
+          (ssh_match?.groups ?? ssh_url_match?.groups)!.owner
+        }/${(ssh_match?.groups ?? ssh_url_match?.groups)!.repo}`
+      : clean_remote_url
+
+  return https_remote_url.replace("https://", `https://oauth2:${encoded_token}@`)
+}
+
 export const configureOrigin = async (git: any) => {
-  if (process.env.GITHUB_TOKEN) {
-    // This doesn't work- it's possible the checkout command needs to use the
-    // github token (in the workflow yaml)
+  const github_token = getGithubPushToken()
+
+  if (github_token) {
     const remote_url = await git.remote(["get-url", "origin"])
+    const new_url = getAuthenticatedGithubRemote(remote_url, github_token)
 
-    // if the remote is in the form of git@github.com:foo/bar.git, convert it to
-    // https://github.com/foo/bar.git
-    if (remote_url.includes("git@")) {
-      const new_url = remote_url!.replace("git@", "https://")
-      await git.removeRemote("origin")
-      await git.addRemote("origin", new_url)
-    }
-
-    if (!remote_url.includes("oauth2:")) {
-      const new_url = remote_url!
-        .replace(
-          "https://",
-          `https://oauth2:${process.env.GITHUB_TOKEN.trim()}@`
-        )
-        .replace(/\n/g, "")
+    if (remote_url.trim().replace(/\n/g, "") !== new_url) {
       await git.removeRemote("origin")
       await git.addRemote("origin", new_url)
     }

--- a/test/configure-origin.test.ts
+++ b/test/configure-origin.test.ts
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict"
+import {
+  configureOrigin,
+  getAuthenticatedGithubRemote,
+  getGithubPushToken,
+} from "../src/release/configure-origin"
+
+type GitCall = {
+  method: "remote" | "removeRemote" | "addRemote"
+  args: unknown[]
+}
+
+const createMockGit = (initial_url: string) => {
+  let current_url = initial_url
+  const calls: GitCall[] = []
+
+  return {
+    remote: async (args: string[]) => {
+      calls.push({ method: "remote", args })
+      return `${current_url}\n`
+    },
+    removeRemote: async (name: string) => {
+      calls.push({ method: "removeRemote", args: [name] })
+    },
+    addRemote: async (name: string, url: string) => {
+      calls.push({ method: "addRemote", args: [name, url] })
+      current_url = url
+    },
+    getCalls: () => calls,
+    getCurrentUrl: () => current_url,
+  }
+}
+
+const withEnv = async (
+  env: Record<string, string | undefined>,
+  run: () => Promise<void>
+) => {
+  const original = {
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+    PVER_GITHUB_TOKEN: process.env.PVER_GITHUB_TOKEN,
+  }
+
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+
+  try {
+    await run()
+  } finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+}
+
+assert.equal(
+  getGithubPushToken({
+    GITHUB_TOKEN: "github-token",
+    PVER_GITHUB_TOKEN: " pver-token ",
+  }),
+  "pver-token",
+  "PVER_GITHUB_TOKEN should take precedence over GITHUB_TOKEN"
+)
+
+assert.equal(
+  getGithubPushToken({ GITHUB_TOKEN: " github-token " }),
+  "github-token",
+  "GITHUB_TOKEN should remain the default token"
+)
+
+assert.equal(
+  getAuthenticatedGithubRemote(
+    "git@github.com:tscircuit/pver.git",
+    "test-token"
+  ),
+  "https://oauth2:test-token@github.com/tscircuit/pver.git",
+  "SSH remotes should be converted to authenticated HTTPS remotes"
+)
+
+assert.equal(
+  getAuthenticatedGithubRemote(
+    "ssh://git@github.com/tscircuit/pver.git",
+    "test-token"
+  ),
+  "https://oauth2:test-token@github.com/tscircuit/pver.git",
+  "ssh:// remotes should be converted to authenticated HTTPS remotes"
+)
+
+assert.equal(
+  getAuthenticatedGithubRemote(
+    "https://github.com/tscircuit/pver.git\n",
+    "test-token"
+  ),
+  "https://oauth2:test-token@github.com/tscircuit/pver.git",
+  "HTTPS remotes should receive the token and be trimmed"
+)
+
+assert.equal(
+  getAuthenticatedGithubRemote(
+    "https://github.com/tscircuit/pver.git",
+    "token:with@symbols"
+  ),
+  "https://oauth2:token%3Awith%40symbols@github.com/tscircuit/pver.git",
+  "tokens should be URL-encoded before they are added to origin"
+)
+
+assert.equal(
+  getAuthenticatedGithubRemote(
+    "https://oauth2:old-token@github.com/tscircuit/pver.git",
+    "test-token"
+  ),
+  "https://oauth2:old-token@github.com/tscircuit/pver.git",
+  "already-authenticated remotes should not be double-authenticated"
+)
+
+const runConfigureOriginTests = async () => {
+  await withEnv(
+    {
+      GITHUB_TOKEN: "github-token",
+      PVER_GITHUB_TOKEN: " pver-token ",
+    },
+    async () => {
+      const git = createMockGit("git@github.com:tscircuit/pver.git")
+
+      await configureOrigin(git)
+
+      assert.equal(
+        git.getCurrentUrl(),
+        "https://oauth2:pver-token@github.com/tscircuit/pver.git",
+        "configureOrigin should rewrite SSH origin using PVER_GITHUB_TOKEN"
+      )
+      assert.deepEqual(
+        git.getCalls().map((call) => call.method),
+        ["remote", "removeRemote", "addRemote"],
+        "configureOrigin should only rewrite origin when the URL changes"
+      )
+    }
+  )
+
+  await withEnv(
+    {
+      GITHUB_TOKEN: undefined,
+      PVER_GITHUB_TOKEN: undefined,
+    },
+    async () => {
+      const git = createMockGit("https://github.com/tscircuit/pver.git")
+
+      await configureOrigin(git)
+
+      assert.deepEqual(
+        git.getCalls(),
+        [],
+        "configureOrigin should not inspect or rewrite origin when no token is set"
+      )
+    }
+  )
+
+  await withEnv(
+    {
+      GITHUB_TOKEN: "new-token",
+      PVER_GITHUB_TOKEN: undefined,
+    },
+    async () => {
+      const git = createMockGit(
+        "https://oauth2:old-token@github.com/tscircuit/pver.git"
+      )
+
+      await configureOrigin(git)
+
+      assert.deepEqual(
+        git.getCalls().map((call) => call.method),
+        ["remote"],
+        "configureOrigin should leave already-authenticated origins alone"
+      )
+      assert.equal(
+        git.getCurrentUrl(),
+        "https://oauth2:old-token@github.com/tscircuit/pver.git",
+        "configureOrigin should not overwrite an existing authenticated origin"
+      )
+    }
+  )
+}
+
+runConfigureOriginTests()
+  .then(() => {
+    console.log("configure-origin tests passed")
+  })
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })


### PR DESCRIPTION
## Summary
- prefer `PVER_GITHUB_TOKEN` over `GITHUB_TOKEN` when pver rewrites `origin` for release pushes
- normalize GitHub SSH and HTTPS remotes before adding token auth, fixing the `git@github.com:owner/repo.git` conversion path
- URL-encode the token before injecting it into the authenticated remote URL
- add regression coverage for token precedence, SSH remotes, `ssh://` remotes, HTTPS remotes, already-authenticated remotes, and the `configureOrigin()` rewrite/no-op paths
- document a protected-branch release workflow in the README

## Verification
- `npm test`
- `npm run typecheck`
- `npm run build`
- `npm run lint`
- `git diff --check`

/claim #1